### PR TITLE
chore: updated expo version to 1.0.1

### DIFF
--- a/apps/expo/app.config.js
+++ b/apps/expo/app.config.js
@@ -32,7 +32,7 @@ const config = {
   scheme: 'paradym',
   slug: 'paradym-wallet',
   owner: 'animo-id',
-  version: '1.0.0',
+  version: '1.0.1',
   orientation: 'portrait',
   icon: './assets/icon.png',
   userInterfaceStyle: 'light',


### PR DESCRIPTION
Previous deployment failed because version 1.0.0 is already released.  So i updated the expo version to 1.0.1