### PR TITLE
fix: OobUrl query fetching

### DIFF
--- a/packages/agent/src/parsers.ts
+++ b/packages/agent/src/parsers.ts
@@ -348,7 +348,7 @@ export async function tryParseDidCommInvitation(
 ): Promise<OutOfBandInvitation | null> {
   try {
     const parsedUrl = queryString.parseUrl(invitationUrl)
-    const updatedInvitationUrl = (parsedUrl['oobUrl'] as string | undefined) ?? invitationUrl
+    const updatedInvitationUrl = (parsedUrl.query['oobUrl'] as string | undefined) ?? invitationUrl
 
     // Try to parse the invitation as an DIDComm invitation.
     // We can't know for sure, as it could be a shortened URL to a DIDComm invitation.


### PR DESCRIPTION
It was working in testing because there is also a url property inside the object that you get back from the parser which is the raw url. So it was a accidental success. With the rename to oobUrl it didn't work anymore because the property is not available in the root object which is also correct. All the queries are inside the query object.

This is tested and it's working.