### PR TITLE
fix: render false boolean

### DIFF
--- a/.yarn/patches/@sd-jwt-decode-npm-0.2.1-4ba346c112.patch
+++ b/.yarn/patches/@sd-jwt-decode-npm-0.2.1-4ba346c112.patch
@@ -1,0 +1,13 @@
+diff --git a/build/disclosures/fromArray.js b/build/disclosures/fromArray.js
+index 57fa9089ded3dada42f081df93a0ee42cfc5b869..1504374a341834a212e0f4d9a5344db574bb31be 100644
+--- a/build/disclosures/fromArray.js
++++ b/build/disclosures/fromArray.js
+@@ -1,7 +1,7 @@
+ "use strict";
+ Object.defineProperty(exports, "__esModule", { value: true });
+ exports.disclosureFromArray = void 0;
+-const disclosureFromArray = (a) => a[2]
++const disclosureFromArray = (a) => a[2] !== undefined
+     ? { salt: a[0], key: a[1], value: a[2] }
+     : { salt: a[0], value: a[1] };
+ exports.disclosureFromArray = disclosureFromArray;

--- a/package.json
+++ b/package.json
@@ -30,7 +30,10 @@
   },
   "resolutions": {
     "@unimodules/react-native-adapter": "./noop",
-    "@unimodules/core": "./noop"
+    "@unimodules/core": "./noop",
+    "@sd-jwt/decode@^0.2.0": "patch:@sd-jwt/decode@npm%3A0.2.1#./.yarn/patches/@sd-jwt-decode-npm-0.2.1-4ba346c112.patch",
+    "@sd-jwt/decode@^0.2.1": "patch:@sd-jwt/decode@npm%3A0.2.1#./.yarn/patches/@sd-jwt-decode-npm-0.2.1-4ba346c112.patch",
+    "@sd-jwt/decode@0.2.1": "patch:@sd-jwt/decode@npm%3A0.2.1#./.yarn/patches/@sd-jwt-decode-npm-0.2.1-4ba346c112.patch"
   },
   "dependencies": {
     "@babel/runtime": "^7.18.9",

--- a/packages/app/utils/formatCredentialSubject.ts
+++ b/packages/app/utils/formatCredentialSubject.ts
@@ -49,12 +49,14 @@ export function formatCredentialSubject(
   const stringRows: CredentialAttributeRow[] = []
   const objectTables: CredentialAttributeTable[] = []
 
-  Object.keys(subject).forEach((key) => {
-    if (key === 'id' || key === 'type') return // omit id and type
+  for (const key of Object.keys(subject)) {
+    // omit id and type
+    if (key === 'id' || key === 'type') continue
 
     const value = subject[key]
 
-    if (!value) return // omit properties with no value
+    // omit properties with no value
+    if (value === undefined) continue
 
     if (typeof value === 'string' && value.startsWith('data:image/')) {
       stringRows.push({
@@ -97,7 +99,7 @@ export function formatCredentialSubject(
         )
       }
     }
-  })
+  }
 
   const tableData: CredentialAttributeTable[] = [
     { title, rows: stringRows, depth, parent },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4530,7 +4530,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sd-jwt/decode@npm:0.2.1, @sd-jwt/decode@npm:^0.2.0, @sd-jwt/decode@npm:^0.2.1":
+"@sd-jwt/decode@npm:0.2.1":
   version: 0.2.1
   resolution: "@sd-jwt/decode@npm:0.2.1"
   dependencies:
@@ -4557,6 +4557,16 @@ __metadata:
     "@sd-jwt/types": 0.3.0
     "@sd-jwt/utils": 0.3.0
   checksum: 4841d29da16ce21dc53bcfd54d410903dfef5594f26270e783b43c296803e1f698ecef65542383acb4beeba3759f2c718aea3c675dab68744440927f0cf9077f
+  languageName: node
+  linkType: hard
+
+"@sd-jwt/decode@patch:@sd-jwt/decode@npm%3A0.2.1#./.yarn/patches/@sd-jwt-decode-npm-0.2.1-4ba346c112.patch::locator=paradym-wallet%40workspace%3A.":
+  version: 0.2.1
+  resolution: "@sd-jwt/decode@patch:@sd-jwt/decode@npm%3A0.2.1#./.yarn/patches/@sd-jwt-decode-npm-0.2.1-4ba346c112.patch::version=0.2.1&hash=fb6dd3&locator=paradym-wallet%40workspace%3A."
+  dependencies:
+    "@sd-jwt/types": 0.2.1
+    "@sd-jwt/utils": 0.2.1
+  checksum: 56a6a5de0fefab5f1c24827087278429bc6fcc4eebdf544de9a475ab7947dcc15e26a329fd09b5aa6eaa575dd2905633e04977b64f0f1ed6082545432e3fd4b5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
It's a bit unfortunate, but there's a bug in sd-jwt library when rendering a boolean value of false (and also a bug in our wallet, but that was easy to fix). So for now I patch it, as Credo is in the process of updating SD-jWT implementation

