### PR TITLE
fix: Removed the if statement to hide specific fields

### DIFF
--- a/packages/app/src/utils/formatCredentialSubject.ts
+++ b/packages/app/src/utils/formatCredentialSubject.ts
@@ -50,9 +50,6 @@ export function formatCredentialSubject(
   const objectTables: CredentialAttributeTable[] = []
 
   for (const key of Object.keys(subject)) {
-    // omit id and type
-    if (key === 'id' || key === 'type') continue
-
     const value = subject[key]
 
     // omit properties with no value


### PR DESCRIPTION
Reason is not really clear why this should be hidden. 

It was quite a surprise when I randomly issued something with a type property