### PR TITLE
feat: authorization code flow ui

### DIFF
--- a/apps/easypid/package.json
+++ b/apps/easypid/package.json
@@ -46,6 +46,7 @@
 		"expo-status-bar": "~1.12.1",
 		"expo-system-ui": "~3.0.6",
 		"expo-updates": "~0.25.16",
+		"expo-web-browser": "~13.0.3",
 		"react": "*",
 		"react-native": "*",
 		"react-native-argon2": "^2.0.1",

--- a/apps/easypid/src/app/(app)/_layout.tsx
+++ b/apps/easypid/src/app/(app)/_layout.tsx
@@ -87,6 +87,12 @@ export default function AppLayout() {
                 gestureEnabled: false,
               }}
             />
+            <Stack.Screen
+              name="notifications/openIdCredentialAuthFlow"
+              options={{
+                gestureEnabled: false,
+              }}
+            />
             <Stack.Screen name="credentials/[id]/index" options={headerNormalOptions} />
             <Stack.Screen name="credentials/[id]/attributes" options={headerNormalOptions} />
             <Stack.Screen name="credentials/requestedAttributes" options={headerNormalOptions} />

--- a/apps/easypid/src/app/(app)/notifications/openIdCredentialAuthFlow.tsx
+++ b/apps/easypid/src/app/(app)/notifications/openIdCredentialAuthFlow.tsx
@@ -1,0 +1,5 @@
+import { FunkeCredentialWithCodeFlowNotificationScreen } from '@easypid/features/receive/FunkeCredentialWithCodeFlowNotificationScreen'
+
+export default function Screen() {
+  return <FunkeCredentialWithCodeFlowNotificationScreen />
+}

--- a/apps/easypid/src/features/receive/slides/AuthCodeFlowSlide.tsx
+++ b/apps/easypid/src/features/receive/slides/AuthCodeFlowSlide.tsx
@@ -1,0 +1,54 @@
+import { CustomIcons, Heading, IllustrationContainer, Paragraph, YStack, useToastController } from '@package/ui'
+import * as WebBrowser from 'expo-web-browser'
+import { DualResponseButtons } from 'packages/app/src/components/DualResponseButtons'
+import type { AuthCodeFlowDetails } from '../FunkeCredentialWithCodeFlowNotificationScreen'
+
+interface AuthCodeFlowSlideProps {
+  authCodeFlowDetails?: AuthCodeFlowDetails
+  onAuthFlowCallback: (result: Record<string, unknown>) => void
+  onCancel: () => void
+}
+
+export const AuthCodeFlowSlide = ({ authCodeFlowDetails, onAuthFlowCallback, onCancel }: AuthCodeFlowSlideProps) => {
+  const toast = useToastController()
+
+  const onPressContinue = async () => {
+    if (!authCodeFlowDetails) return
+    const result = await WebBrowser.openAuthSessionAsync(authCodeFlowDetails.openUrl)
+
+    if (result.type !== 'success') {
+      toast.show('Authorization not succeeded', { customData: { preset: 'warning' } })
+      return
+    }
+
+    // === IMPLEMENT HERE ===
+    onAuthFlowCallback({
+      result,
+    })
+  }
+
+  return (
+    <YStack fg={1} jc="space-between">
+      <YStack gap="$4">
+        <Heading>Authorization required</Heading>
+        <IllustrationContainer>
+          <CustomIcons.Connect color="$white" size={56} />
+        </IllustrationContainer>
+        <Paragraph>
+          To receive this credential, you need to authorize with your account. You will now be redirected to the
+          issuer's website.
+        </Paragraph>
+      </YStack>
+
+      <YStack btw="$0.5" borderColor="$grey-200" py="$4" mx="$-4" px="$4" bg="$background">
+        <DualResponseButtons
+          align="horizontal"
+          acceptText="Authenticate"
+          declineText="Stop"
+          onAccept={onPressContinue}
+          onDecline={onCancel}
+        />
+      </YStack>
+    </YStack>
+  )
+}

--- a/apps/easypid/src/features/receive/slides/VerifyPartySlide.tsx
+++ b/apps/easypid/src/features/receive/slides/VerifyPartySlide.tsx
@@ -6,6 +6,7 @@ import { DualResponseButtons, useHaptics, useWizard } from 'packages/app/src'
 import { formatRelativeDate } from 'packages/utils/src'
 
 interface VerifyPartySlideProps {
+  type: 'offer' | 'request'
   host: string
   name?: string
   logo?: DisplayImage
@@ -15,6 +16,7 @@ interface VerifyPartySlideProps {
 }
 
 export const VerifyPartySlide = ({
+  type,
   host,
   name,
   logo,
@@ -51,11 +53,17 @@ export const VerifyPartySlide = ({
             <Heading variant="h2" numberOfLines={2} center fontSize={24}>
               {name ? `Interact with ${name}?` : 'Organization not verified'}
             </Heading>
-            <Paragraph center px="$4">
-              {name
-                ? `${name} wants to request information from you.`
-                : 'An unknown organization wants to request information from you.'}
-            </Paragraph>
+            {type === 'offer' ? (
+              <Paragraph center px="$4">
+                {name ? `${name} wants to offer you a card.` : 'An unknown organization wants to offer you a card.'}
+              </Paragraph>
+            ) : (
+              <Paragraph center px="$4">
+                {name
+                  ? `${name} wants to request information from you.`
+                  : 'An unknown organization wants to request information from you.'}
+              </Paragraph>
+            )}
           </Stack>
         </YStack>
 

--- a/apps/easypid/src/features/share/FunkePresentationNotificationScreen.tsx
+++ b/apps/easypid/src/features/share/FunkePresentationNotificationScreen.tsx
@@ -54,6 +54,7 @@ export function FunkePresentationNotificationScreen({
             screen: (
               <VerifyPartySlide
                 key="verify-issuer"
+                type="request"
                 name={verifierName}
                 host={host}
                 logo={logo}

--- a/apps/easypid/src/features/wallet/FunkeWalletScreen.tsx
+++ b/apps/easypid/src/features/wallet/FunkeWalletScreen.tsx
@@ -41,6 +41,10 @@ export function FunkeWalletScreen() {
     handlePressOut: qrHandlePressOut,
   } = useScaleAnimation({ scaleInValue: 0.95 })
 
+  const onTestFlow = () => {
+    push('/notifications/openIdCredentialAuthFlow?uri=test&data=test')
+  }
+
   return (
     <FlexPage p={0} safeArea="b" gap={0}>
       <AnimatedStack entering={FadeIn.duration(200)}>
@@ -74,6 +78,18 @@ export function FunkeWalletScreen() {
           <Paragraph fontWeight="$bold" color="$primary-500">
             Scan QR-Code
           </Paragraph>
+          <Button.Solid
+            h="$3.5"
+            px="$5"
+            br="$12"
+            bg="$grey-100"
+            color="$grey-900"
+            flexDirection="row"
+            onPress={onTestFlow}
+            scaleOnPress
+          >
+            Test
+          </Button.Solid>
         </Stack>
       </AnimatedStack>
       {credentials.length === 0 ? (

--- a/packages/ui/assets/Connect.tsx
+++ b/packages/ui/assets/Connect.tsx
@@ -1,0 +1,19 @@
+import Svg, { Path, G, Rect, type SvgProps } from 'react-native-svg'
+
+export function ConnectIcon({ width = 48, height = 48, color = 'black', ...props }: SvgProps) {
+  return (
+    <Svg width={width} height={height} viewBox="0 0 48 48" fill={color} {...props}>
+      <G id="Layer_2" data-name="Layer 2">
+        <G id="invisible_box" data-name="invisible box">
+          <Rect width="48" height="48" fill="none" />
+        </G>
+        <G id="horoscope">
+          <G>
+            <Path d="M25.6,25.6,22.2,29,19,25.8l3.4-3.4a2,2,0,0,0-2.8-2.8L16.2,23l-1.3-1.3a1.9,1.9,0,0,0-2.8,0l-3,3a9.8,9.8,0,0,0-3,7,9.1,9.1,0,0,0,1.8,5.6L4.6,40.6a1.9,1.9,0,0,0,0,2.8,1.9,1.9,0,0,0,2.8,0l3.2-3.2a10.1,10.1,0,0,0,5.9,1.9,10.2,10.2,0,0,0,7.1-2.9l3-3a2,2,0,0,0,.6-1.4,1.7,1.7,0,0,0-.6-1.4L25,31.8l3.4-3.4a2,2,0,0,0-2.8-2.8Z" />
+            <Path d="M43.4,4.6a1.9,1.9,0,0,0-2.8,0L37.2,8a10,10,0,0,0-13,.9l-3,3a2,2,0,0,0-.6,1.4,1.7,1.7,0,0,0,.6,1.4L32.9,26.4a1.9,1.9,0,0,0,2.8,0l3-2.9a9.9,9.9,0,0,0,2.9-7.1A10.4,10.4,0,0,0,40,10.9l3.4-3.5A1.9,1.9,0,0,0,43.4,4.6Z" />
+          </G>
+        </G>
+      </G>
+    </Svg>
+  )
+}

--- a/packages/ui/src/content/Icon.tsx
+++ b/packages/ui/src/content/Icon.tsx
@@ -72,9 +72,9 @@ import {
   TrashIcon as TrashFilledIcon,
 } from 'react-native-heroicons/solid'
 
-import { ExclamationIcon } from '../../assets/Exclamation'
-
 import { styled } from 'tamagui'
+import { ConnectIcon } from '../../assets/Connect'
+import { ExclamationIcon } from '../../assets/Exclamation'
 
 export const LucideIcons = {
   Trash2,
@@ -167,6 +167,7 @@ export const HeroIcons = {
 
 export const CustomIcons = {
   Exclamation: wrapLocalSvg(ExclamationIcon as React.ComponentType<SvgProps>),
+  Connect: wrapLocalSvg(ConnectIcon as React.ComponentType<SvgProps>),
 }
 
 export type CustomIconProps = SvgProps & {
@@ -183,7 +184,6 @@ function wrapLocalSvg(SvgComponent: React.ComponentType<CustomIconProps>) {
     {
       accept: {
         color: 'color',
-        size: 'size',
       },
     }
   )

--- a/packages/ui/src/content/IconContainer.tsx
+++ b/packages/ui/src/content/IconContainer.tsx
@@ -8,8 +8,8 @@ interface IconContainerProps extends StackProps {
   scaleOnPress?: boolean
 }
 
-export function IconContainer({ icon, scaleOnPress, ...props }: IconContainerProps) {
-  const { handlePressIn, handlePressOut, pressStyle } = useScaleAnimation({ scaleInValue: 0.9 })
+export function IconContainer({ icon, scaleOnPress = true, ...props }: IconContainerProps) {
+  const { handlePressIn, handlePressOut, pressStyle } = useScaleAnimation({ scaleInValue: scaleOnPress ? 0.9 : 1 })
 
   return (
     <AnimatedStack p="$2" m="$-2" style={pressStyle} onPressIn={handlePressIn} onPressOut={handlePressOut} {...props}>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,6 +162,9 @@ importers:
       expo-updates:
         specifier: ~0.25.16
         version: 0.25.27(expo@51.0.38(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0)))
+      expo-web-browser:
+        specifier: ~13.0.3
+        version: 13.0.3(expo@51.0.38(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0)))
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -6155,6 +6158,11 @@ packages:
   expo-updates@0.25.27:
     resolution: {integrity: sha512-1hyYZqBEXcAiEuSRPJ6dINTndGlWi6/bwlyYGjSnyoYfu/vzZQrJ+XA8JUP4EvJ3b0g8a0UOIjlDJ9ke9kMcfg==}
     hasBin: true
+    peerDependencies:
+      expo: '*'
+
+  expo-web-browser@13.0.3:
+    resolution: {integrity: sha512-HXb7y82ApVJtqk8tManyudtTrCtx8xcUnVzmJECeHCB0SsWSQ+penVLZxJkcyATWoJOsFMnfVSVdrTcpKKGszQ==}
     peerDependencies:
       expo: '*'
 
@@ -17632,7 +17640,7 @@ snapshots:
       did-resolver: 4.1.0
       elliptic: 6.6.0
       js-sha3: 0.8.0
-      multiformats: 9.7.1
+      multiformats: 9.9.0
       uint8arrays: 3.1.1
 
   did-jwt@7.4.7:
@@ -17644,7 +17652,7 @@ snapshots:
       canonicalize: 2.0.0
       did-resolver: 4.1.0
       multibase: 4.0.6
-      multiformats: 9.7.1
+      multiformats: 9.9.0
       uint8arrays: 3.1.1
 
   did-jwt@8.0.4:
@@ -18328,6 +18336,10 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  expo-web-browser@13.0.3(expo@51.0.38(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))):
+    dependencies:
+      expo: 51.0.38(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))
 
   expo@51.0.38(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0)):
     dependencies:


### PR DESCRIPTION
I've started with the authorization code flow UI. I'm not sure how it needs to be implemented so this is all guess work. I've made a separate flow because not sure how much specific logic there is, and also to keep the regular flow a bit cleaner. If it turns out it's very little difference we can merge them into the regular `<FunkeOpenIdCredentialNotificationScreen />`.

Maybe you can leave some feedback on things i'm missing or what I can still add to make it easier for you to implement.

https://github.com/user-attachments/assets/ec727cd5-26b0-48dc-a3d9-d8aa4fff8866

