### PR TITLE
fix: unlocking with face id

### DIFF
--- a/packages/secure-store/secure-wallet-key/SecureUnlockProvider.tsx
+++ b/packages/secure-store/secure-wallet-key/SecureUnlockProvider.tsx
@@ -171,7 +171,6 @@ function _useSecureUnlockState<Context extends Record<string, unknown>>(): Secur
         if (!canTryUnlockingUsingBiometrics) return null
 
         setIsUnlocking(true)
-        setCanTryUnlockingUsingBiometrics(false)
         setBiometricsUnlockAttempts((attempts) => attempts + 1)
         try {
           const walletKey = await secureWalletKey.getWalletKeyUsingBiometrics(secureWalletKey.getWalletKeyVersion())
@@ -189,7 +188,7 @@ function _useSecureUnlockState<Context extends Record<string, unknown>>(): Secur
           }
           // If other error, we will allow up to three attempts
           else if (biometricsUnlockAttempts < 3) {
-            setCanTryUnlockingUsingBiometrics(true)
+            setCanTryUnlockingUsingBiometrics(false)
           }
         } finally {
           setIsUnlocking(false)

--- a/packages/secure-store/secure-wallet-key/SecureUnlockProvider.tsx
+++ b/packages/secure-store/secure-wallet-key/SecureUnlockProvider.tsx
@@ -187,7 +187,7 @@ function _useSecureUnlockState<Context extends Record<string, unknown>>(): Secur
             setCanTryUnlockingUsingBiometrics(false)
           }
           // If other error, we will allow up to three attempts
-          else if (biometricsUnlockAttempts < 3) {
+          else if (biometricsUnlockAttempts > 3) {
             setCanTryUnlockingUsingBiometrics(false)
           }
         } finally {


### PR DESCRIPTION
@TimoGlastra This fixes the unlocking issue, but it might break other things. Any reason why `setCanTryUnlockingUsingBiometrics` before unlocking?