### PR TITLE
fix: pid setup fix

### DIFF
--- a/apps/easypid/src/features/pid/FunkePidSetupScreen.tsx
+++ b/apps/easypid/src/features/pid/FunkePidSetupScreen.tsx
@@ -43,8 +43,6 @@ export function FunkePidSetupScreen() {
   const [onIdCardPinReEnter, setOnIdCardPinReEnter] = useState<(idCardPin: string) => Promise<void>>()
   const [userName, setUserName] = useState<string>()
   const [isScanning, setIsScanning] = useState(false)
-  const [isAcquiringAccessToken, setIsAcquiringAccessToken] = useState(false)
-  const [isRetrievingCredential, setIsRetrievingCredential] = useState(false)
 
   const onEnterPin: ReceivePidUseCaseFlowOptions['onEnterPin'] = useCallback(
     (options) => {
@@ -229,14 +227,11 @@ export function FunkePidSetupScreen() {
   }
 
   const onScanningComplete = async () => {
-    if (isAcquiringAccessToken) return
     if (!receivePidUseCase) {
       toast.show('Not ready to receive PID', { customData: { preset: 'danger' } })
       pushToWallet()
       return
     }
-
-    setIsAcquiringAccessToken(true)
 
     try {
       setIdCardScanningState((state) => ({
@@ -266,7 +261,6 @@ export function FunkePidSetupScreen() {
   }
 
   const retrieveCredential = async () => {
-    if (isRetrievingCredential) return
     if (receivePidUseCase?.state !== 'retrieve-credential') {
       toast.show('Not ready to retrieve PID', { customData: { preset: 'danger' } })
       pushToWallet()
@@ -278,8 +272,6 @@ export function FunkePidSetupScreen() {
       pushToWallet()
       return
     }
-
-    setIsRetrievingCredential(true)
 
     try {
       // Retrieve Credential
@@ -324,6 +316,7 @@ export function FunkePidSetupScreen() {
         pushToWallet()
         return
       }
+
       toast.show('Something went wrong', { customData: { preset: 'danger' } })
       pushToWallet()
     }
@@ -335,12 +328,12 @@ export function FunkePidSetupScreen() {
         {
           step: 'id-card-start',
           progress: 20,
-          screen: () => <PidSetupStartSlide {...getPidSetupSlideContent('id-card-start')} />,
+          screen: <PidSetupStartSlide {...getPidSetupSlideContent('id-card-start')} />,
         },
         {
           step: 'id-card-pin',
           progress: 30,
-          screen: () => (
+          screen: (
             <PidWalletPinSlide
               title="Enter your app PIN code"
               subtitle="Enter the PIN code you use to unlock your wallet."
@@ -352,7 +345,7 @@ export function FunkePidSetupScreen() {
           step: 'id-card-requested-attributes',
           progress: 40,
           backIsCancel: true,
-          screen: () => (
+          screen: (
             <PidReviewRequestSlide
               {...getPidSetupSlideContent('id-card-requested-attributes')}
               requestedAttributes={eidCardRequestedAccessRights}
@@ -363,7 +356,7 @@ export function FunkePidSetupScreen() {
           step: 'id-card-pin',
           progress: 50,
           backIsCancel: true,
-          screen: () => (
+          screen: (
             <PidEidCardPinSlide
               {...getPidSetupSlideContent('id-card-pin')}
               onEnterPin={onIdCardPinReEnter ?? onIdCardPinEnter}
@@ -374,7 +367,7 @@ export function FunkePidSetupScreen() {
           step: 'id-card-start-scan',
           progress: 60,
           backIsCancel: true,
-          screen: () => (
+          screen: (
             <PidCardScanSlide
               {...getPidSetupSlideContent('id-card-start-scan')}
               progress={idCardScanningState.progress}
@@ -393,7 +386,7 @@ export function FunkePidSetupScreen() {
           step: 'id-card-fetch',
           progress: 80,
           backIsCancel: true,
-          screen: () => (
+          screen: (
             <PidIdCardFetchSlide
               {...getPidSetupSlideContent('id-card-fetch')}
               userName={userName}

--- a/apps/easypid/src/features/pid/FunkePidSetupScreen.tsx
+++ b/apps/easypid/src/features/pid/FunkePidSetupScreen.tsx
@@ -43,6 +43,8 @@ export function FunkePidSetupScreen() {
   const [onIdCardPinReEnter, setOnIdCardPinReEnter] = useState<(idCardPin: string) => Promise<void>>()
   const [userName, setUserName] = useState<string>()
   const [isScanning, setIsScanning] = useState(false)
+  const [isAcquiringAccessToken, setIsAcquiringAccessToken] = useState(false)
+  const [isRetrievingCredential, setIsRetrievingCredential] = useState(false)
 
   const onEnterPin: ReceivePidUseCaseFlowOptions['onEnterPin'] = useCallback(
     (options) => {
@@ -227,11 +229,14 @@ export function FunkePidSetupScreen() {
   }
 
   const onScanningComplete = async () => {
+    if (isAcquiringAccessToken) return
     if (!receivePidUseCase) {
       toast.show('Not ready to receive PID', { customData: { preset: 'danger' } })
       pushToWallet()
       return
     }
+
+    setIsAcquiringAccessToken(true)
 
     try {
       setIdCardScanningState((state) => ({
@@ -261,6 +266,7 @@ export function FunkePidSetupScreen() {
   }
 
   const retrieveCredential = async () => {
+    if (isRetrievingCredential) return
     if (receivePidUseCase?.state !== 'retrieve-credential') {
       toast.show('Not ready to retrieve PID', { customData: { preset: 'danger' } })
       pushToWallet()
@@ -272,6 +278,8 @@ export function FunkePidSetupScreen() {
       pushToWallet()
       return
     }
+
+    setIsRetrievingCredential(true)
 
     try {
       // Retrieve Credential
@@ -316,7 +324,6 @@ export function FunkePidSetupScreen() {
         pushToWallet()
         return
       }
-
       toast.show('Something went wrong', { customData: { preset: 'danger' } })
       pushToWallet()
     }

--- a/apps/easypid/src/features/pid/PidEidCardFetchSlide.tsx
+++ b/apps/easypid/src/features/pid/PidEidCardFetchSlide.tsx
@@ -1,4 +1,5 @@
 import { Heading, Paragraph, YStack } from '@package/ui'
+import { useWizard } from 'packages/app/src'
 import { useEffect } from 'react'
 import { OnboardingIdCardFetch } from '../onboarding/screens/id-card-fetch'
 
@@ -11,12 +12,19 @@ interface PidIdCardFetchSlideProps {
 }
 
 export function PidIdCardFetchSlide({ title, subtitle, userName, onFetch, onComplete }: PidIdCardFetchSlideProps) {
+  const { completeProgressBar } = useWizard()
   // biome-ignore lint/correctness/useExhaustiveDependencies: We fetch when this slide is mounted
   useEffect(() => {
     // We can't navigate to the next step from the SlideWizard, so we start the fetching of the credential
     // when this slide is mounted.
     void onFetch()
   }, [])
+
+  useEffect(() => {
+    if (userName) {
+      completeProgressBar()
+    }
+  }, [completeProgressBar, userName])
 
   return (
     <YStack fg={1} gap="$6">

--- a/packages/app/src/components/SlideWizard.tsx
+++ b/packages/app/src/components/SlideWizard.tsx
@@ -12,7 +12,7 @@ import { WizardProvider } from './WizardContext'
 export type SlideStep = {
   step: string
   progress: number
-  screen: () => React.ReactNode
+  screen: (() => React.ReactNode) | React.ReactElement
   backIsCancel?: boolean
 }
 
@@ -161,7 +161,7 @@ export function SlideWizard({ steps, onCancel, isError, errorScreen, confirmatio
             fg={1}
             px="$4"
           >
-            <Screen />
+            {typeof Screen === 'function' ? <Screen /> : Screen}
           </ScrollableStack>
         </AnimatedStack>
       </FlexPage>


### PR DESCRIPTION
Not an ideal fix, still thinking how we can do it better.

The problem is that because we now do () => <Screen />, it re-renders everytime something changes in the properties passed to that screen. This means that once the state changes after the scan is complete, the screen renders again, and it triggers again. 

I tried fixing it with useMemo but that leads to the same thing. 

- [x] PIN screen still is a bit weird.
