### PR TITLE
refactor: handle connection flow and errors

### DIFF
--- a/apps/easypid/src/app/(app)/federation.tsx
+++ b/apps/easypid/src/app/(app)/federation.tsx
@@ -3,16 +3,15 @@ import type { TrustedEntity } from '@package/agent'
 import { useLocalSearchParams } from 'expo-router'
 
 export default function Screen() {
-  const { entityId, trustedEntities, name, logo } = useLocalSearchParams()
+  const { trustedEntities, name, logo } = useLocalSearchParams<{
+    trustedEntities: string
+    name: string
+    logo?: string
+  }>()
 
   const trustedEntitiesArray = JSON.parse(decodeURIComponent(trustedEntities as string)) as Array<TrustedEntity>
 
   return (
-    <FunkeFederationDetailScreen
-      entityId={entityId as string}
-      trustedEntities={trustedEntitiesArray}
-      name={name as string}
-      logo={logo as string}
-    />
+    <FunkeFederationDetailScreen trustedEntities={trustedEntitiesArray} name={name as string} logo={logo as string} />
   )
 }

--- a/apps/easypid/src/features/activity/activityRecord.ts
+++ b/apps/easypid/src/features/activity/activityRecord.ts
@@ -24,9 +24,12 @@ interface BaseActivity {
   status: ActivityStatus
   date: string
   entity: {
-    // entity id can either be: did or https url
-    id: string
-    did?: string
+    // FIXME: we need to avoid id collisions. So we should
+    // add a prefix probably. So
+    // didcomm-connection:
+    //
+    // entity id can either be: did or https url or connection id
+    id?: string
     host?: string
     name?: string
     logo?: DisplayImage
@@ -110,7 +113,7 @@ export const useActivities = ({ filters }: { filters?: { entityId?: string } } =
 export const addReceivedActivity = async (
   agent: AppAgent,
   input: {
-    entityId: string
+    entityId?: string
     name: string
     host?: string
     logo?: DisplayImage
@@ -157,7 +160,9 @@ export const addSharedOrSignedActivity = async (
 
 export function addSharedActivityForCredentialsForRequest(
   agent: AppAgent,
-  credentialsForRequest: Pick<CredentialsForProofRequest, 'verifier' | 'formattedSubmission'>,
+  credentialsForRequest: Pick<CredentialsForProofRequest, 'formattedSubmission'> & {
+    verifier: Omit<CredentialsForProofRequest['verifier'], 'entityId'> & { entityId?: string }
+  },
   status: ActivityStatus,
   transaction?: FormattedTransactionData
 ) {

--- a/apps/easypid/src/features/didcomm/ConnectionSlides.tsx
+++ b/apps/easypid/src/features/didcomm/ConnectionSlides.tsx
@@ -57,7 +57,8 @@ const ConnectionSuccessSlide = ({ name, onComplete }: ConnectionSuccessSlideProp
         <YStack gap="$4" ai="center">
           <Heading>Connection established</Heading>
           <Paragraph ta="center">
-            You can now receive notifications from <Paragraph fontWeight="$semiBold">{name}</Paragraph>
+            You can now receive notifications from {'\n'}
+            <Paragraph fontWeight="$semiBold">{name}</Paragraph>
           </Paragraph>
         </YStack>
         <Spacer />

--- a/apps/easypid/src/features/didcomm/CredentialSlides.tsx
+++ b/apps/easypid/src/features/didcomm/CredentialSlides.tsx
@@ -27,7 +27,7 @@ export function CredentialSlides({ isExisting, credentialExchangeId, onCancel, o
 
     if (w3cRecord) {
       await addReceivedActivity(agent, {
-        entityId: credentialExchange?.connectionId as string,
+        entityId: credentialExchange?.connectionId,
         name: display.issuer.name,
         logo: display.issuer.logo,
         backgroundColor: '#ffffff', // Default to a white background for now

--- a/apps/easypid/src/features/didcomm/DidCommNotificationScreen.tsx
+++ b/apps/easypid/src/features/didcomm/DidCommNotificationScreen.tsx
@@ -56,11 +56,8 @@ export function DidCommNotificationScreen() {
   const onCancel = () => handleNavigation('back')
   const onComplete = () => handleNavigation('replace')
 
-  console.log('flow', flow)
-  console.log('readyToNavigate', readyToNavigate)
   const onConnectionAccept = async () => {
     const result = await acceptConnection()
-    console.log('result', result)
     if (result.success) {
       setFlow({
         id:

--- a/apps/easypid/src/features/receive/slides/InteractionErrorSlide.tsx
+++ b/apps/easypid/src/features/receive/slides/InteractionErrorSlide.tsx
@@ -1,13 +1,23 @@
 import { Button, Heading, HeroIcons, Paragraph, ScrollView, Stack, XStack, YStack } from '@package/ui'
 import { useState } from 'react'
 
-interface CredentialErrorSlideProps {
+interface InteractionErrorSlideProps {
   reason?: string
+  flowType: 'issue' | 'verify' | 'connect' | 'sign'
   onCancel: () => void
 }
 
-export const CredentialErrorSlide = ({ reason, onCancel }: CredentialErrorSlideProps) => {
+export const InteractionErrorSlide = ({ reason, onCancel, flowType }: InteractionErrorSlideProps) => {
   const [scrollViewHeight, setScrollViewHeight] = useState(0)
+
+  const message =
+    flowType === 'connect'
+      ? 'An error occured while connecting. Generate a new QR-code or try again later.'
+      : flowType === 'issue'
+        ? 'An error occured while fetching the card information. Ask the issuer to generate a new QR-code or try again later.'
+        : flowType === 'verify'
+          ? 'An error occured while sharing the card information. Ask the verifier to generate a new QR-code or try again later.'
+          : 'An error occured while signing with your card information. Ask the verifier to generate a new QR-code or try again later'
 
   return (
     <YStack fg={1} jc="space-between">
@@ -20,10 +30,7 @@ export const CredentialErrorSlide = ({ reason, onCancel }: CredentialErrorSlideP
                 <HeroIcons.NoSymbol color="$grey-800" size={32} />
               </XStack>
             </Stack>
-            <Paragraph>
-              An error occured while fetching the card information. Ask the issuer to generate a new QR-code or try
-              again later.
-            </Paragraph>
+            <Paragraph>{message}</Paragraph>
           </YStack>
           {reason && scrollViewHeight !== 0 && (
             <YStack>

--- a/apps/easypid/src/features/receive/slides/VerifyPartySlide.tsx
+++ b/apps/easypid/src/features/receive/slides/VerifyPartySlide.tsx
@@ -17,15 +17,17 @@ import {
 import { useRouter } from 'expo-router'
 import { formatRelativeDate } from 'packages/utils/src'
 import { useState } from 'react'
+import { useActivities } from '../../activity/activityRecord'
+
+const NO_ENTITY_ID = 'NO_ENTITY_ID'
 
 interface VerifyPartySlideProps {
   type: 'offer' | 'request' | 'signing' | 'connect'
   host?: string
   name?: string
-  entityId: string
+  entityId?: string
   logo?: DisplayImage
   backgroundColor?: string
-  lastInteractionDate?: string
   onContinue?: () => Promise<void>
   onDecline?: () => void
   trustedEntities?: Array<TrustedEntity>
@@ -37,7 +39,6 @@ export const VerifyPartySlide = ({
   name,
   logo,
   backgroundColor,
-  lastInteractionDate,
   onContinue,
   onDecline,
   trustedEntities,
@@ -47,6 +48,8 @@ export const VerifyPartySlide = ({
   const { onNext, onCancel } = useWizard()
   const { withHaptics } = useHaptics()
   const [isLoading, setIsLoading] = useState(false)
+  const { activities } = useActivities({ filters: { entityId: entityId ?? NO_ENTITY_ID } })
+  const lastInteractionDate = activities[0]?.date
 
   const handleContinue = async () => {
     setIsLoading(true)
@@ -68,7 +71,7 @@ export const VerifyPartySlide = ({
 
   const onPressVerifiedIssuer = withHaptics(() => {
     router.push(
-      `/federation?name=${encodeURIComponent(name ?? '')}&logo=${encodeURIComponent(logo?.url ?? '')}&entityId=${encodeURIComponent(entityId)}&trustedEntities=${encodeURIComponent(JSON.stringify(trustedEntitiesWithoutSelf ?? []))}`
+      `/federation?name=${encodeURIComponent(name ?? '')}&logo=${encodeURIComponent(logo?.url ?? '')}&trustedEntities=${encodeURIComponent(JSON.stringify(trustedEntitiesWithoutSelf ?? []))}`
     )
   })
 

--- a/apps/easypid/src/features/share/FunkeMdocOfflineSharingScreen.tsx
+++ b/apps/easypid/src/features/share/FunkeMdocOfflineSharingScreen.tsx
@@ -144,7 +144,6 @@ export function FunkeMdocOfflineSharingScreen({
       {
         formattedSubmission: submission,
         verifier: {
-          entityId: '6df3d57e-4c9c-41c3-bb9f-936d88c0968d',
           hostName: undefined,
           logo: undefined,
           name: 'Unknown party',

--- a/apps/easypid/src/features/share/FunkePresentationNotificationScreen.tsx
+++ b/apps/easypid/src/features/share/FunkePresentationNotificationScreen.tsx
@@ -2,6 +2,7 @@ import type { DisplayImage, FormattedSubmission, FormattedTransactionData, Trust
 
 import type { OverAskingResponse } from '@easypid/use-cases/OverAskingApi'
 import { type SlideStep, SlideWizard } from '@package/app'
+import { InteractionErrorSlide } from '../receive/slides/InteractionErrorSlide'
 import { LoadingRequestSlide } from '../receive/slides/LoadingRequestSlide'
 import { VerifyPartySlide } from '../receive/slides/VerifyPartySlide'
 import { PinSlide } from './slides/PinSlide'
@@ -11,10 +12,9 @@ import { SignAndShareSlide } from './slides/SignAndShareSlide'
 import { SigningSlide } from './slides/SigningSlide'
 
 interface FunkePresentationNotificationScreenProps {
-  entityId: string
+  entityId?: string
   verifierName?: string
   logo?: DisplayImage
-  lastInteractionDate?: string
   overAskingResponse?: OverAskingResponse
   trustedEntities?: Array<TrustedEntity>
   submission?: FormattedSubmission
@@ -23,16 +23,18 @@ interface FunkePresentationNotificationScreenProps {
   transaction?: FormattedTransactionData
   onAccept: () => Promise<void>
   onDecline: () => void
+  onCancel: () => void
   onComplete: () => void
+  errorReason?: string
 }
 
 export function FunkePresentationNotificationScreen({
   entityId,
   verifierName,
   logo,
-  lastInteractionDate,
   usePin,
   onAccept,
+  onCancel,
   onDecline,
   isAccepting,
   submission,
@@ -40,6 +42,7 @@ export function FunkePresentationNotificationScreen({
   overAskingResponse,
   trustedEntities,
   transaction,
+  errorReason,
 }: FunkePresentationNotificationScreenProps) {
   return (
     <SlideWizard
@@ -61,7 +64,6 @@ export function FunkePresentationNotificationScreen({
                 entityId={entityId}
                 name={verifierName}
                 logo={logo}
-                lastInteractionDate={lastInteractionDate}
                 trustedEntities={trustedEntities}
               />
             ),
@@ -122,7 +124,15 @@ export function FunkePresentationNotificationScreen({
           },
         ].filter(Boolean) as SlideStep[]
       }
-      isError={false}
+      errorScreen={() => (
+        <InteractionErrorSlide
+          key="presentation-error"
+          flowType={transaction?.type === 'qes_authorization' ? 'sign' : 'verify'}
+          reason={errorReason}
+          onCancel={onCancel}
+        />
+      )}
+      isError={!!errorReason}
       onCancel={onDecline}
     />
   )

--- a/apps/easypid/src/features/wallet/FunkeFederationDetailScreen.tsx
+++ b/apps/easypid/src/features/wallet/FunkeFederationDetailScreen.tsx
@@ -21,16 +21,10 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context'
 interface FunkeFederationDetailScreenProps {
   name: string
   logo?: string
-  entityId?: string
   trustedEntities?: Array<TrustedEntity>
 }
 
-export function FunkeFederationDetailScreen({
-  name,
-  logo,
-  entityId,
-  trustedEntities = [],
-}: FunkeFederationDetailScreenProps) {
+export function FunkeFederationDetailScreen({ name, logo, trustedEntities = [] }: FunkeFederationDetailScreenProps) {
   const { handleScroll, isScrolledByOffset, scrollEventThrottle } = useScrollViewPosition()
   const { bottom } = useSafeAreaInsets()
   const scrollViewRef = useRef<ScrollViewRefType>(null)

--- a/packages/agent/src/hooks/useDidCommConnectionActions.ts
+++ b/packages/agent/src/hooks/useDidCommConnectionActions.ts
@@ -12,10 +12,6 @@ export function useDidCommConnectionActions(resolved?: ResolveOutOfBandInvitatio
       if (!resolved) throw new Error("Missing 'resolved' parameter")
 
       const result = await acceptOutOfBandInvitation(agent, resolved.outOfBandInvitation, resolved.flowType)
-      if (!result.success) {
-        throw new Error('Error creating connection')
-      }
-
       return result
     },
   })


### PR DESCRIPTION
Some additions to #324, to correctly handle errors, and also reuse the error screen for all flows.