### PR TITLE
fix: redirect works when app is longer in background

### DIFF
--- a/apps/easypid/src/app/+native-intent.tsx
+++ b/apps/easypid/src/app/+native-intent.tsx
@@ -1,5 +1,6 @@
 import 'fast-text-encoding'
 
+import { TypedArrayEncoder } from '@credo-ts/core'
 import { appScheme } from '@easypid/constants'
 import { parseInvitationUrl } from '@package/agent'
 import { deeplinkSchemes } from '@package/app'
@@ -57,14 +58,18 @@ export async function redirectSystemPath({ path, initial }: { path: string; init
     }
 
     if (redirectPath) {
+      // Always make the user authenticate first when opening with a deeplink
+      const encodedRedirect = TypedArrayEncoder.toBase64URL(TypedArrayEncoder.fromString(redirectPath))
+      const newPath = `/authenticate?redirectAfterUnlock=${encodedRedirect}`
+
       // NOTE: it somehow doesn't handle the intent if the app is already open
       // so we replace the router to the path. I think it can break easily though if e.g.
       // the wallet is locked in the background. Not sure how to proceed, this is best effort fix
       if (!initial) {
-        router.replace(redirectPath)
+        router.replace(newPath)
         return null
       }
-      return redirectPath
+      return newPath
     }
 
     void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error)

--- a/apps/easypid/src/app/authenticate.tsx
+++ b/apps/easypid/src/app/authenticate.tsx
@@ -27,6 +27,13 @@ export default function Authenticate() {
   const isLoading =
     secureUnlock.state === 'acquired-wallet-key' || (secureUnlock.state === 'locked' && secureUnlock.isUnlocking)
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: no recheck required, only on mount
+  useEffect(() => {
+    if (secureUnlock.state === 'unlocked' && redirectAfterUnlock) {
+      secureUnlock.lock()
+    }
+  }, [])
+
   // After resetting the wallet, we want to avoid prompting for face id immediately
   // So we add an artificial delay
   useEffect(() => {

--- a/packages/app/src/components/TextBackButton.tsx
+++ b/packages/app/src/components/TextBackButton.tsx
@@ -6,8 +6,16 @@ export function TextBackButton() {
   const router = useRouter()
   const { withHaptics } = useHaptics()
 
+  const handleBack = () => {
+    if (router.canGoBack()) {
+      router.back()
+    } else {
+      router.replace('/')
+    }
+  }
+
   return (
-    <Button.Text color="$primary-500" fontWeight="$semiBold" onPress={withHaptics(() => router.back())} scaleOnPress>
+    <Button.Text color="$primary-500" fontWeight="$semiBold" onPress={withHaptics(handleBack)} scaleOnPress>
       <HeroIcons.ArrowLeft mr={-4} color="$primary-500" strokeWidth={2} size={20} /> Back
     </Button.Text>
   )


### PR DESCRIPTION
replaces #337 

- Request authentication when a deeplink is being used (same fix as in #337)
- Fixes the issue when the app is longer in the background that the deeplink still works, comes with the side effect that when the app is not so long in the background that it needs to re-auth, which I think is okay. Mainly, because re-authenticating within an such a fraud sensitive platform is not a bad thing. Most people, if not all, use biometrics and make the authentication extremely fast.

I could not test it with the Ausweis flow as I do not have a card and I could not find the website anymore. I think the deeplink working has a priority over the ausweis flow for now.