### PR TITLE
fix: remove date suffix

### DIFF
--- a/packages/utils/src/format.ts
+++ b/packages/utils/src/format.ts
@@ -53,16 +53,10 @@ export function formatRelativeDate(date: Date, now: Date = new Date(), includeTi
       ? t({ id: 'dateFormatting.yesterdayAtTime', message: `Yesterday at ${formatTime(date)}` })
       : t({ id: 'dateFormatting.yesterday', message: 'Yesterday' })
   }
-  return `${
-    date.toLocaleDateString(getLocaleForFormat(), { month: 'long', day: 'numeric' }) +
-    (date.getDate() === 1 || date.getDate() === 21 || date.getDate() === 31
-      ? 'st'
-      : date.getDate() === 2 || date.getDate() === 22
-        ? 'nd'
-        : date.getDate() === 3 || date.getDate() === 23
-          ? 'rd'
-          : 'th')
-  } ${includeTime ? `at ${formatTime(date)}` : ''}`
+  return `${date.toLocaleDateString(getLocaleForFormat(), {
+    month: 'long',
+    day: 'numeric',
+  })} ${includeTime ? `at ${formatTime(date)}` : ''}`
 }
 
 /**


### PR DESCRIPTION
It doesn't work in other languages besides english. Still shows `August 15`, which is correct, `August 15th` may read just a bit smoother, but better to have it correct in all languages