### PR TITLE
fix: deeplinking and routing

### DIFF
--- a/apps/easypid/src/features/didcomm/DidCommNotificationScreen.tsx
+++ b/apps/easypid/src/features/didcomm/DidCommNotificationScreen.tsx
@@ -55,17 +55,18 @@ export function DidCommNotificationScreen() {
   }>()
   const { acceptConnection, declineConnection, display } = useDidCommConnectionActions(resolvedInvitation)
   const { t } = useLingui()
-  const handleNavigation = (type: 'replace' | 'back') => {
+
+  const handleNavigation = () => {
     // When starting from the inbox, we want to go back to the inbox on finish
     if (params.navigationType === 'inbox') {
       router.back()
     } else {
-      pushToWallet(type)
+      pushToWallet()
     }
   }
 
-  const onCancel = () => handleNavigation('back')
-  const onComplete = () => handleNavigation('replace')
+  const onCancel = () => handleNavigation()
+  const onComplete = () => handleNavigation()
 
   const onConnectionAccept = async () => {
     const result = await acceptConnection()

--- a/apps/easypid/src/features/pid/FunkePidSetupScreen.tsx
+++ b/apps/easypid/src/features/pid/FunkePidSetupScreen.tsx
@@ -464,7 +464,7 @@ export function FunkePidSetupScreen() {
             <PidIdCardFetchSlide
               {...getPidSetupSlideContent(userName ? 'id-card-complete' : 'id-card-fetch', t)}
               userName={userName}
-              onComplete={() => pushToWallet('replace')}
+              onComplete={() => pushToWallet()}
             />
           ),
         },

--- a/apps/easypid/src/features/receive/FunkeOpenIdCredentialNotificationScreen.tsx
+++ b/apps/easypid/src/features/receive/FunkeOpenIdCredentialNotificationScreen.tsx
@@ -184,10 +184,10 @@ export function FunkeCredentialNotificationScreen() {
     [agent, setErrorReasonWithError, t]
   )
 
-  // TODO: Should we add this to the activitiy? We also don't do it for issuance
+  // TODO: Should we add this to the activity? We also don't do it for issuance
   const onProofDecline = async () => {
     toast.show(t(commonMessages.informationRequestDeclined), { customData: { preset: 'danger' } })
-    pushToWallet('back')
+    pushToWallet()
   }
 
   const onCompleteCredentialRetrieval = async () => {
@@ -398,8 +398,8 @@ export function FunkeCredentialNotificationScreen() {
     ]
   )
 
-  const onCancel = () => pushToWallet('back')
-  const onGoToWallet = () => pushToWallet('replace')
+  const onCancel = () => pushToWallet()
+  const onGoToWallet = () => pushToWallet()
 
   const isAuthFlow =
     !preAuthGrant &&

--- a/apps/easypid/src/features/share/FunkeMdocOfflineSharingScreen.tsx
+++ b/apps/easypid/src/features/share/FunkeMdocOfflineSharingScreen.tsx
@@ -159,7 +159,7 @@ export function FunkeMdocOfflineSharingScreen({
 
   const onProofComplete = () => {
     shutdownDataTransfer()
-    pushToWallet('replace')
+    pushToWallet()
   }
 
   const addActivity = async (status: Exclude<ActivityStatus, 'pending'>) => {

--- a/apps/easypid/src/features/share/FunkeOpenIdPresentationNotificationScreen.tsx
+++ b/apps/easypid/src/features/share/FunkeOpenIdPresentationNotificationScreen.tsx
@@ -244,7 +244,7 @@ export function FunkeOpenIdPresentationNotificationScreen() {
     })
   }, [agent, credentialsForRequest, formattedTransactionData, pushToWallet, stopOverAsking, t, toast])
 
-  const replace = useCallback(() => pushToWallet('replace'), [pushToWallet])
+  const replace = useCallback(() => pushToWallet(), [pushToWallet])
 
   return (
     <FunkePresentationNotificationScreen

--- a/packages/app/src/components/TextBackButton.tsx
+++ b/packages/app/src/components/TextBackButton.tsx
@@ -13,7 +13,7 @@ export function TextBackButton() {
     if (router.canGoBack()) {
       router.back()
     } else {
-      router.replace('/')
+      router.dismissTo('/')
     }
   }
 

--- a/packages/app/src/hooks/usePushToWallet.tsx
+++ b/packages/app/src/hooks/usePushToWallet.tsx
@@ -4,18 +4,5 @@ import { useCallback } from 'react'
 export function usePushToWallet() {
   const router = useRouter()
 
-  const pushToWallet = useCallback(
-    (variant: 'replace' | 'back' = 'back') => {
-      if (variant === 'replace' || !router.canGoBack()) {
-        router.replace('/')
-      } else {
-        router.back()
-        // If we do a PIN confirmation we need to go back twice
-        if (router.canGoBack()) router.back()
-      }
-    },
-    [router]
-  )
-
-  return pushToWallet
+  return useCallback(() => router.dismissTo('/'), [router])
 }


### PR DESCRIPTION
Everytime we try to fix something about the routing we break something new. Now the redirect after deeplinking was broken.

I have simplified the setup, by basically always using `dismissTo`. This will dismiss back if possible, or otherwise navigate forward. It doesn't have the same issues as replace, which doesn't reset the previous pages (just the last one)