### PR TITLE
fix: fixed main page opacity staying at 0

### DIFF
--- a/apps/easypid/src/features/wallet/FunkeWalletScreen.tsx
+++ b/apps/easypid/src/features/wallet/FunkeWalletScreen.tsx
@@ -56,7 +56,7 @@ export function FunkeWalletScreen() {
           <InboxIcon />
         </XStack>
 
-        <AnimatedStack fg={1} entering={useSpringify(FadeIn, 200)} opacity={0}>
+        <AnimatedStack fg={1} entering={useSpringify(FadeIn, 200)}>
           <ScrollView scrollEnabled={false} contentContainerStyle={{ fg: 1 }}>
             <YStack fg={1} f={1} gap="$4">
               <YStack ai="center" jc="center" gap="$2">


### PR DESCRIPTION
No idea why it stayed transparent in dev while working properly in prod, but this still applies the fade in animation properly and doesn't stay transparent.

fixes #451