### PR TITLE
fix: allow deletion of credentials

### DIFF
--- a/packages/app/src/components/DeleteCredentialSheet.tsx
+++ b/packages/app/src/components/DeleteCredentialSheet.tsx
@@ -2,8 +2,8 @@ import { dcApiRegisterOptions } from '@easypid/utils/dcApiRegisterOptions'
 import { useLingui } from '@lingui/react/macro'
 import { commonMessages } from '@package/translations'
 import { useToastController } from '@package/ui'
-import type { CredentialCategoryMetadata, CredentialId } from '@paradym/wallet-sdk'
-import { useCredentialByCategory, useCredentialById, useParadym } from '@paradym/wallet-sdk'
+import type { CredentialId } from '@paradym/wallet-sdk'
+import { useParadym } from '@paradym/wallet-sdk'
 import { useNavigation } from 'expo-router'
 import { useHaptics } from '../hooks'
 import { ConfirmationSheet } from './ConfirmationSheet'
@@ -12,40 +12,34 @@ interface DeleteCredentialSheetProps {
   isSheetOpen: boolean
   setIsSheetOpen: (isOpen: boolean) => void
   id: CredentialId
-  category?: CredentialCategoryMetadata['credentialCategory']
   name: string
 }
 
 export function DeleteCredentialSheet({ isSheetOpen, setIsSheetOpen, id, name }: DeleteCredentialSheetProps) {
   const { paradym } = useParadym('unlocked')
-
   const toast = useToastController()
   const navigation = useNavigation()
   const { withHaptics, successHaptic, errorHaptic } = useHaptics()
   const { t } = useLingui()
-  const { credential } = useCredentialById(id)
-  const { credentials } = useCredentialByCategory(credential?.category?.credentialCategory ?? 'NO_CATEGORY')
 
   const onDeleteCredential = async () => {
     try {
-      // Only navigate back and update UI after successful deletion
-      navigation.goBack()
       setIsSheetOpen(false)
-
-      await paradym.deleteCredentials(
-        dcApiRegisterOptions({ paradym, credentialIds: credentials?.map((c) => c.id) ?? id })
-      )
+      await paradym.deleteCredentials(dcApiRegisterOptions({ paradym, credentialIds: [id] }))
 
       toast.show(t(commonMessages.toastCardArchived), {
         customData: { preset: 'success' },
       })
+
       successHaptic()
-    } catch (_error) {
+    } catch (error) {
+      paradym.logger.error('Error occurred while trying to delete a credential', { cause: error })
       toast.show(t(commonMessages.toastCardDeleteError), {
         customData: { preset: 'danger' },
       })
       errorHaptic()
     }
+    navigation.goBack()
   }
 
   const onCancel = withHaptics(() => setIsSheetOpen(false))


### PR DESCRIPTION
Did not work due to some legacy code we had for deleting a category. Code was never used.
