### PR TITLE
fix(sdk): don't append wallet key version to store id twice

### DIFF
--- a/packages/sdk/src/ParadymWalletSdk.tsx
+++ b/packages/sdk/src/ParadymWalletSdk.tsx
@@ -1,7 +1,9 @@
 import { AskarStoreInvalidKeyError } from '@credo-ts/askar'
 import { CredoError, type X509ModuleConfigOptions } from '@credo-ts/core'
+import { agentDependencies } from '@credo-ts/react-native'
 import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query'
 import { createContext, type PropsWithChildren, useContext, useState } from 'react'
+import { moveFile } from 'react-native-fs'
 import {
   type AgentForAgentType,
   type AgentType,
@@ -366,7 +368,6 @@ function useSecureUnlockState(configuration: SetupParadymWalletSdkOptions): Secu
       unlock: async (options) => {
         try {
           const walletKeyVersion = secureWalletKey.getWalletKeyVersion()
-          const id = configuration.id ? `${configuration.id}-${walletKeyVersion}` : `paradym-wallet-${walletKeyVersion}`
           const key = walletKey
 
           const isBiometricsEnabled = options?.enableBiometrics ?? getIsBiometricsEnabled()
@@ -381,9 +382,19 @@ function useSecureUnlockState(configuration: SetupParadymWalletSdkOptions): Secu
 
           const pws = new ParadymWalletSdk({
             ...configuration,
-            id,
             key,
           })
+
+          // Dev-only migration from the double-versioned store id (e.g. paradym-wallet-1-1).
+          // No production installs have the old id. Remove after a few releases.
+          const fs = new agentDependencies.FileSystem()
+          const walletDirectory = `${fs.dataPath}/wallet/${pws.walletId}`
+          const legacyWalletDirectory = `${walletDirectory}-${walletKeyVersion}`
+
+          if (!(await fs.exists(walletDirectory)) && (await fs.exists(legacyWalletDirectory))) {
+            await moveFile(legacyWalletDirectory, walletDirectory).catch(() => {})
+          }
+
           await pws.agent.initialize()
           setState('unlocked')
           setParadym(pws)


### PR DESCRIPTION
The unlock flow appended the wallet key version to the store id and `setupAgent` appended it again, so stores ended up as `easypid-wallet-1-1` instead of `easypid-wallet-1`. The id is now versioned only in `getBaseModules`.

Existing stores with the doubled id (dev only, no production installs) are migrated on unlock by renaming the wallet directory. The rename is atomic and best effort; remove after a few releases.

Verified on device: legacy store is renamed and opens with existing data intact, fresh installs unaffected.